### PR TITLE
Classify as PlaybackDevice, not AudioSystem.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 3.0.2
+
+- Classify as `PlaybackDevice`, not `AudioSystem`.
+
 ## 3.0.1
 
 Fixes for new Samsung TV update, otherwise TV reverted to TV speaker automatically

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -191,7 +191,7 @@ pub fn main() {
             on_command_received(sender.clone(), command)
         }))
         .log_message_callback(Box::new(on_log_message))
-        .device_types(CecDeviceTypeVec::new(CecDeviceType::AudioSystem))
+        .device_types(CecDeviceTypeVec::new(CecDeviceType::PlaybackDevice))
         .build()
         .unwrap();
     let connection: CecConnection = cfg.open().unwrap();


### PR DESCRIPTION
Resolves #12

Signed-off-by: Sami Salonen <ssalonen@gmail.com>

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/ssalonen/cec-alsa-sync/blob/master/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/ssalonen/cec-alsa-sync/blob/master/CHANGELOG.md
-->
